### PR TITLE
Display recentlyPlayed Games in Library

### DIFF
--- a/api/steam-api.js
+++ b/api/steam-api.js
@@ -20,7 +20,6 @@ router.get('/get-player-summary', cors(corsOptions), async function (req, res) {
     + '&steamids='
     + steamID
     + '&format=json'
-  console.log("Still called for some reason")
   axios.get(getPlayerSummaryWithAPIKey)
     .then((response) => {
       // handle success

--- a/src/components/hero-capsule.tsx
+++ b/src/components/hero-capsule.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+type HeroCapsuleProps = {
+  name: string;
+  appID: string;
+  children: React.ReactNode;
+};
+
+export const HeroCapsule = ({
+  name,
+  appID,
+  children,
+}: HeroCapsuleProps) => {
+  return (
+    <div>
+      <div className="flex flex-1 justify-center py-4 text-3xl">{name}</div>
+    </div>
+  );
+};
+
+export default HeroCapsule;

--- a/src/components/hero-capsule.tsx
+++ b/src/components/hero-capsule.tsx
@@ -1,21 +1,28 @@
-import React from "react";
+import React from "react"
 
 type HeroCapsuleProps = {
-  name: string;
-  appID: string;
-  children: React.ReactNode;
-};
+  name: string
+  appID: string
+  libraryCapsuleURL: string
+  children: React.ReactNode
+}
 
 export const HeroCapsule = ({
   name,
   appID,
+  libraryCapsuleURL,
   children,
 }: HeroCapsuleProps) => {
+  const imageURL = libraryCapsuleURL + appID + "/hero_capsule.jpg"
   return (
     <div>
-      <div className="flex flex-1 justify-center py-4 text-3xl">{name}</div>
+      {/* If image does not successfully render */}
+      <div>
+        <img src={imageURL} alt={name} />
+      </div>
+      <div className="flex flex-1 justify-center py-4">{name}</div>
     </div>
-  );
-};
+  )
+}
 
-export default HeroCapsule;
+export default HeroCapsule

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -17,7 +17,7 @@ const Layout = ({ pageTitle, children }: LayoutProps) => {
       </div>
       <main>
         <div className="container mx-auto flex flex-col justify-center">
-          <h1 className="text-3xl font-bold underline pb-8">{pageTitle}</h1>
+          <h1 className="pb-8 text-2xl font-bold underline">{pageTitle}</h1>
           {children}
         </div>
       </main>

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -1,30 +1,32 @@
 import React from "react"
 
-export const RecentLibrary = (recentlyPlayedLibraryProp: Array<Object>) => {
-  // console.log(recentlyPlayedLibrary.gamesArray[0])
-  const recentLibrary = recentlyPlayedLibraryProp.gamesArray
-  console.log("recentLibrary")
-  console.log(recentLibrary)
-  // const recentLibrary: Array<Object> = Array.from(arrayProp.gamesArray)
-  /* recentLibrary.forEach((x) => {
-    console.log(x)
-  }) */
+type RecentLibraryProps = {
+  recentlyPlayedLibrary: Array<Object>
+  children: React.ReactNode
+}
+
+export const RecentLibrary = ({
+  recentlyPlayedLibrary,
+  children,
+}: RecentLibraryProps) => {
+  
+  for (var i = 0; i < recentlyPlayedLibrary.length; i++) {
+    console.log(recentlyPlayedLibrary[i].name)
+  }
   return (
     <div>
-    <ul className="">
+      <div className="grid grid-cols-5 flex-row items-center gap-4">
         {/* for each item in api resopnse game array */}
         {/* {console.log(gamesArray[0].name)} */}
-        {recentLibrary.forEach(x => {
-          <li>{x.name} </li>
-        })}
         {/* Display Game Hero Image component */}
-        {/* <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
+        {/* <div className="flex flex-1 justify-center py-4 text-3xl">{recentLibrary[0].name}</div> */}
         <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
         <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
         <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
         <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div> */}
-      </ul>
+        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
+        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
+      </div>
     </div>
   )
 }

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -10,9 +10,11 @@ export const RecentLibrary = ({
   recentlyPlayedLibrary,
   children,
 }: RecentLibraryProps) => {
-  const steamContentServer = "https://cdn.cloudflare.steamstatic.com/steam/apps/"
+  const steamContentServer =
+    "https://cdn.cloudflare.steamstatic.com/steam/apps/"
   return (
     <div>
+      <h1 className="pb-8 text-2xl font-bold underline">Recent Library</h1>
       <div className="grid grid-cols-5 flex-row items-center gap-4">
         {/* for each item in api resopnse game array */}
         {/* Display Game Hero Image component */}

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -10,6 +10,7 @@ export const RecentLibrary = ({
   recentlyPlayedLibrary,
   children,
 }: RecentLibraryProps) => {
+  const steamContentServer = "https://cdn.cloudflare.steamstatic.com/steam/apps/"
   return (
     <div>
       <div className="grid grid-cols-5 flex-row items-center gap-4">
@@ -19,7 +20,8 @@ export const RecentLibrary = ({
         {recentlyPlayedLibrary.map((game: Object) => (
           <HeroCapsule
             name={game.name}
-            key={game.appid}
+            appID={game.appid}
+            libraryCapsuleURL={steamContentServer}
             children={undefined}
           />
         ))}

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -9,23 +9,15 @@ export const RecentLibrary = ({
   recentlyPlayedLibrary,
   children,
 }: RecentLibraryProps) => {
-  
-  for (var i = 0; i < recentlyPlayedLibrary.length; i++) {
-    console.log(recentlyPlayedLibrary[i].name)
-  }
   return (
     <div>
       <div className="grid grid-cols-5 flex-row items-center gap-4">
         {/* for each item in api resopnse game array */}
-        {/* {console.log(gamesArray[0].name)} */}
         {/* Display Game Hero Image component */}
         {/* <div className="flex flex-1 justify-center py-4 text-3xl">{recentLibrary[0].name}</div> */}
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
-        <div className="flex flex-1 justify-center py-4 text-3xl">Game</div>
+          {recentlyPlayedLibrary.map((game: Object) => (
+            <div className="flex flex-1 justify-center py-4 text-3xl" >{game.name}</div>
+          ))}
       </div>
     </div>
   )

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import HeroCapsule from "../components/hero-capsule"
 
 type RecentLibraryProps = {
   recentlyPlayedLibrary: Array<Object>
@@ -15,9 +16,13 @@ export const RecentLibrary = ({
         {/* for each item in api resopnse game array */}
         {/* Display Game Hero Image component */}
         {/* <div className="flex flex-1 justify-center py-4 text-3xl">{recentLibrary[0].name}</div> */}
-          {recentlyPlayedLibrary.map((game: Object) => (
-            <div className="flex flex-1 justify-center py-4 text-3xl" >{game.name}</div>
-          ))}
+        {recentlyPlayedLibrary.map((game: Object) => (
+          <HeroCapsule
+            name={game.name}
+            key={game.appid}
+            children={undefined}
+          />
+        ))}
       </div>
     </div>
   )

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,11 +1,4 @@
 import * as React from "react"
-import {getSteamUser} from "../../api/get-steam-user"
-
-//
-function getPlayerSummary() {
-  console.log('Get Player summary from steamapi')
-  // return getSteamUser();
-}
 
 const Searchbar = () => {
   return (
@@ -21,7 +14,6 @@ const Searchbar = () => {
       <div>
         <button
           className="h-4/6 justify-center rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
-          onClick={getPlayerSummary}
         >
           Search
         </button>

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -30,8 +30,6 @@ const ProfilePage = () => {
       // handle success
       setPlayerSummary(res[0].data.response.players[0])
       setRecentlyPlayed(res[1].data.response.games)
-    /*   console.log("Games Array")
-      console.log(res[1].data.response.games) */
     })
     .catch((error: String) => {
       // handle error
@@ -54,7 +52,8 @@ const ProfilePage = () => {
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black " />
       <RecentLibrary 
-        gamesArray={recentlyPlayed}
+        recentlyPlayedLibrary={recentlyPlayed}
+        children={undefined}
         />
       <Link to="/">
         <p>Back to Home</p>

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -13,30 +13,37 @@ const steamID2 = "76561197960434622"
 const ProfilePage = () => {
   const [playerSummary, setPlayerSummary] = React.useState({})
   const [recentlyPlayed, setRecentlyPlayed] = React.useState([])
-  const getPlayerSummary = axios.get("http://localhost:3000/steam-api/get-player-summary", {
-    params: {
-      steamIDParam: steamId,
-    },
-  })
-  const getRecentlyPlayed = axios.get("http://localhost:3000/steam-api/get-recently-played-games", {
-    params: {
-      steamIDParam: steamId,
-    },
-  })
+  const getPlayerSummary = axios.get(
+    "http://localhost:3000/steam-api/get-player-summary",
+    {
+      params: {
+        steamIDParam: steamId,
+      },
+    }
+  )
+  const getRecentlyPlayed = axios.get(
+    "http://localhost:3000/steam-api/get-recently-played-games",
+    {
+      params: {
+        steamIDParam: steamId,
+      },
+    }
+  )
   // Call get-steam-user with user supplied steamId
   React.useEffect(() => {
-    axios.all([getPlayerSummary,getRecentlyPlayed])
-    .then((res: JSON) => {
-      // handle success
-      setPlayerSummary(res[0].data.response.players[0])
-      setRecentlyPlayed(res[1].data.response.games)
-    })
-    .catch((error: String) => {
-      // handle error
-      console.log("Error: " + error)
-    })
+    axios
+      .all([getPlayerSummary, getRecentlyPlayed])
+      .then((res: JSON) => {
+        // handle success
+        setPlayerSummary(res[0].data.response.players[0])
+        setRecentlyPlayed(res[1].data.response.games)
+      })
+      .catch((error: String) => {
+        // handle error
+        console.log("Error: " + error)
+      })
   }, [])
-      return (
+  return (
     <Layout pageTitle={profileName}>
       {/* PlayerSummary Component */}
       <PlayerSummary
@@ -50,11 +57,11 @@ const ProfilePage = () => {
             < Individual Steam Game> Component
             */}
       <hr className="py-4 " />
-      <div className="flex-grow border-t-2 border-black " />
-      <RecentLibrary 
+      <div className="flex-grow border-t-2 border-black py-4" />
+      <RecentLibrary
         recentlyPlayedLibrary={recentlyPlayed}
         children={undefined}
-        />
+      />
       <Link to="/">
         <p>Back to Home</p>
       </Link>

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -12,7 +12,7 @@ const steamID2 = "76561197960434622"
 
 const ProfilePage = () => {
   const [playerSummary, setPlayerSummary] = React.useState({})
-  const [recentlyPlayed, setRecentlyPlayed] = React.useState({})
+  const [recentlyPlayed, setRecentlyPlayed] = React.useState([])
   const getPlayerSummary = axios.get("http://localhost:3000/steam-api/get-player-summary", {
     params: {
       steamIDParam: steamId,


### PR DESCRIPTION
# Problem 
Display response recent game library in a Grid Pattern. 
Use hero capsule images if possible.

# Solution
- Get appid
- Display hero_capsule image for game and Name of game under image
# Impact
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/3e96c6a3-0ea8-41a8-a8da-259615cb80ab)
## Potential Issue
When a Steam name is too long, displaces the alignment of the hero capsule for example:
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/5b90a1cf-52bb-47a0-9549-84a90650382c)


# Test Plan
1. Clone `steam-reaction` to local environment
2. Open a terminal in the local repository, enter `npm i` or `npm install`
3. Run `npm run dev` to start front-end
4. Run `npm start` to start back-end
5. Open `localhost:8000/` in a browser.

# Helpful Links: 
- [Get Hero Capsule Image ](https://stackoverflow.com/questions/53963328/how-do-i-get-a-hash-for-a-picture-form-a-steam-game)
  - Example: "The Walking Dead: Saints & Sinners: Retribution"
    -  https://cdn.cloudflare.steamstatic.com/steam/apps/1947500/hero_capsule.jpg

Closes #48 
