### PR TITLE
Implement GetOwnedGames Steam Web API call

### DIFF
--- a/api/steam-api.js
+++ b/api/steam-api.js
@@ -77,4 +77,25 @@ router.get('/get-friends-list', cors(corsOptions) , async function (req, res) {
 });
 
 
+// Get all owned games with appinfo excluding free games
+router.get('/get-owned-games', cors(corsOptions) , async function (req, res) {
+  let steamID = req.query.steamIDParam
+  let getOwnedGames =
+  process.env.STEAM_GET_OWNED_GAMES
+    + process.env.STEAM_API_KEY // Get API Key from env
+    + '&steamid='
+    +  steamID
+    + '&format=json&include_appinfo=true'
+  axios.get(getOwnedGames)
+    .then((response) => {
+      // handle success
+      res.send(response.data)
+    })
+    .catch((error) => {
+      // handle error
+      console.log(error)
+      return
+    });
+});
+
 module.exports = router;

--- a/src/hooks/get-owned-games.tsx
+++ b/src/hooks/get-owned-games.tsx
@@ -1,0 +1,19 @@
+import axios from "axios"
+
+function getOwnedGames(id: string) {
+  return axios
+    .get("http://localhost:3000/steam-api/get-owned-games", {
+      params: {
+        steamIDParam: id,
+      },
+    })
+    .then((res: Object) => {
+      return res.data.response.games
+    })
+    .catch((error: String) => {
+      // handle error
+      console.log("Error: " + error)
+    })
+}
+
+export default getOwnedGames

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -3,13 +3,23 @@ import * as React from "react"
 import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
+import getOwnedGames from "../../hooks/get-owned-games"
 const axios = require("axios")
 
 const pageTitle = "Compared Games"
 
 // Get playerSummary and Friendslist from previous component
 const CompareGamesPage = (summariesObject: Object) => {
+  let userOwnedGames = []
+  let friendOwnedGames = []
   React.useEffect(() => {
+    getOwnedGames(summariesObject.location.state.userSummary.steamid)
+      .then((returnedUserGames: Array<Object>) => {
+        userOwnedGames = returnedUserGames
+      })
+      .catch((error: String) => {
+        console.log("Error: " + error)
+      })
     // Get MyGames
     // Get FriendsGames
     // Get ComparedGames
@@ -20,7 +30,7 @@ const CompareGamesPage = (summariesObject: Object) => {
 
   return (
     <Layout pageTitle={pageTitle}>
-      <div className=" grid divide-x-4 grid-cols-2">
+      <div className=" grid grid-cols-2 divide-x-4">
         <PlayerSummary
           personaName={summariesObject.location.state.userSummary.personaname}
           imageURL={summariesObject.location.state.userSummary.avatarfull}

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -34,7 +34,7 @@ const CompareGamesPage = (summariesObject: Object) => {
       </div>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
-      {/* Games Library Component
+      {/* Compared Games Library Component
         Uses "Same Games" method  */}
       <Link to="/">
         <p>Back to Home</p>


### PR DESCRIPTION
# Problem 
Implement api call to [GetOwnedGames (v0001)](https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29)

# Solution

- [x] Add "getownedgames" method to `steam-api.js`
- [x] Log owned games for "spilledcoffee"

# Impact
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/bf28460d-45f7-4aec-b3a8-829c08bf24f9)

# Test Plan
1. Clone the repo to your local environment
2. `npm install`
3. Run `npm run dev`
4. Run `npm start` to start backend server
5. Navigate to `http://localhost:8000`
6. Click "Steam Profile"
7. Click "To Friends List"
8. Click "Compare Games" on any of the listed friends

Closes #65 