### PR TITLE
67 - Get Games that are common between User and Friend

### DIFF
--- a/api/steam-api.js
+++ b/api/steam-api.js
@@ -85,7 +85,7 @@ router.get('/get-owned-games', cors(corsOptions) , async function (req, res) {
     + process.env.STEAM_API_KEY // Get API Key from env
     + '&steamid='
     +  steamID
-    + '&format=json&include_appinfo=true'
+    + '&format=json&include_appinfo=true&include_played_free_games=true'
   axios.get(getOwnedGames)
     .then((response) => {
       // handle success

--- a/src/components/hero-capsule.tsx
+++ b/src/components/hero-capsule.tsx
@@ -13,7 +13,7 @@ export const HeroCapsule = ({
   libraryCapsuleURL,
   children,
 }: HeroCapsuleProps) => {
-  const imageURL = libraryCapsuleURL + appID + "/hero_capsule.jpg"
+  const imageURL = libraryCapsuleURL + appID + "/library_600x900.jpg"
   return (
     <div>
       {/* If image does not successfully render */}

--- a/src/hooks/check-empty-object.tsx
+++ b/src/hooks/check-empty-object.tsx
@@ -1,0 +1,11 @@
+function isEmpty(obj: Object) {
+  for (const prop in obj) {
+    if (Object.hasOwn(obj, prop)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export default isEmpty

--- a/src/hooks/find-common-games.tsx
+++ b/src/hooks/find-common-games.tsx
@@ -1,0 +1,24 @@
+import axios from "axios"
+import getOwnedGames from "./get-owned-games"
+import isEmpty from "./check-empty-object"
+
+function findCommonGames(userSteamId: String, friendSteamId: String) {
+  let userOwnedGames: Object[] = []
+  let friendOwnedGames: Object[] = []
+  let commonGames: Array<Object> = []
+
+  return Promise.all([getOwnedGames(userSteamId), getOwnedGames(friendSteamId)])
+    .then((res: any) => {
+      if (isEmpty(res[0]) || isEmpty(res[1])) return []
+      return res
+    })
+    .then((res: any) => {
+      if (isEmpty(res)) return []
+    })
+    .catch((err: any) => {
+      console.log(err)
+      return
+    })
+}
+
+export default findCommonGames

--- a/src/hooks/find-common-games.tsx
+++ b/src/hooks/find-common-games.tsx
@@ -5,15 +5,28 @@ import isEmpty from "./check-empty-object"
 function findCommonGames(userSteamId: String, friendSteamId: String) {
   let userOwnedGames: Object[] = []
   let friendOwnedGames: Object[] = []
-  let commonGames: Array<Object> = []
+  let commonGames: Map<String, String> = new Map()
 
   return Promise.all([getOwnedGames(userSteamId), getOwnedGames(friendSteamId)])
     .then((res: any) => {
       if (isEmpty(res[0]) || isEmpty(res[1])) return []
-      return res
-    })
-    .then((res: any) => {
-      if (isEmpty(res)) return []
+      if (res[0].length > res[1].length) {
+        // make a map with larger array's appid as key
+        let userGameMap = new Map(res[0].map((game) => [game.appid, game.name]))
+       // filter userGames array for games with appid in "userGameMap"
+        let commonGames = res[1].filter((friendGame) =>
+          userGameMap.has(friendGame.appid)
+        )
+        return commonGames
+      } else {
+        // make a map with larger array's appid as key
+        let friendGameMap = new Map(res[1].map((game) => [game.appid, game.name]))
+        // filter userGames array for games with appid in "friendGameMap"
+        let commonGames = res[0].filter((friendGame) =>
+          userGameMap.has(friendGame.appid)
+        )
+        return commonGames
+      }
     })
     .catch((err: any) => {
       console.log(err)

--- a/src/hooks/find-common-games.tsx
+++ b/src/hooks/find-common-games.tsx
@@ -13,14 +13,16 @@ function findCommonGames(userSteamId: String, friendSteamId: String) {
       if (res[0].length > res[1].length) {
         // make a map with larger array's appid as key
         let userGameMap = new Map(res[0].map((game) => [game.appid, game.name]))
-       // filter userGames array for games with appid in "userGameMap"
+        // filter userGames array for games with appid in "userGameMap"
         let commonGames = res[1].filter((friendGame) =>
           userGameMap.has(friendGame.appid)
         )
         return commonGames
       } else {
         // make a map with larger array's appid as key
-        let friendGameMap = new Map(res[1].map((game) => [game.appid, game.name]))
+        let friendGameMap = new Map(
+          res[1].map((game) => [game.appid, game.name])
+        )
         // filter userGames array for games with appid in "friendGameMap"
         let commonGames = res[0].filter((friendGame) =>
           userGameMap.has(friendGame.appid)

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -1,10 +1,11 @@
-import { Link } from "gatsby"
+import { Link, navigate } from "gatsby"
 import * as React from "react"
 import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
 import getOwnedGames from "../../hooks/get-owned-games"
 import findCommonGames from "../../hooks/find-common-games"
+import RecentLibrary from "../../components/recent-library"
 
 const axios = require("axios")
 
@@ -25,8 +26,8 @@ const CompareGamesPage = (summariesObject: Object) => {
       ),
     ])
       .then((res: any) => {
-        if (res.length == 0) publicFriendsLibrary = false
-        // console.log(res)
+        if (res[0].length == 0) publicFriendsLibrary = false
+        setCommonGames(res[0])
       })
       .catch((error: String) => {})
   }, [])
@@ -47,16 +48,24 @@ const CompareGamesPage = (summariesObject: Object) => {
       </div>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
-      {/* Compared Games Library Component
-        Uses "Same Games" method  */}
-      {isFriendsLibraryPublic == true ? (
-        <p> Library!</p>
-      ) : (
-        <p>Friends Library Not Public</p>
-      )}
+      <button
+        onClick={async (event) => {
+          await navigate(-1)
+        }}
+      >
+        <p>Back to Friends List</p>
+      </button>
       <Link to="/">
         <p>Back to Home</p>
       </Link>
+      {isFriendsLibraryPublic == true ? (
+        <RecentLibrary
+          recentlyPlayedLibrary={commonGames}
+          children={undefined}
+        />
+      ) : (
+        <p>Friends Library Not Public</p>
+      )}
     </Layout>
   )
 }

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -4,6 +4,7 @@ import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
 import getOwnedGames from "../../hooks/get-owned-games"
+import findCommonGames from "../../hooks/find-common-games"
 
 const axios = require("axios")
 
@@ -11,30 +12,22 @@ const pageTitle = "Compared Games"
 
 // Get playerSummary and Friendslist from previous component
 const CompareGamesPage = (summariesObject: Object) => {
-  let userOwnedGames = []
-  let friendOwnedGames = []
+  let isFriendsLibraryPublic = true
   const [commonGames, setCommonGames] = React.useState([])
 
   React.useEffect(() => {
-    // Get User Games
-    getOwnedGames(summariesObject.location.state.userSummary.steamid)
-      .then((returnedUserGames: Array<Object>) => {
-        userOwnedGames = returnedUserGames
-      })
-      .catch((error: String) => {
-        console.log("Error: " + error)
-      })
-    // Get Friend's Games
-    getOwnedGames(summariesObject.location.state.friendSummary.friendId)
-      .then((returnedFriendGames: Array<Object>) => {
-        friendOwnedGames = returnedFriendGames
-      })
-      .catch((error: String) => {
-        console.log("Error: " + error)
-      })
     // Get Common games
-    Promise.all([])
-      .then((res: Array<Object>) => {})
+
+    Promise.all([
+      findCommonGames(
+        summariesObject.location.state.userSummary.steamid,
+        summariesObject.location.state.friendSummary.friendId
+      ),
+    ])
+      .then((res: any) => {
+        if (res.length == 0) publicFriendsLibrary = false
+        // console.log(res)
+      })
       .catch((error: String) => {})
   }, [])
 
@@ -56,6 +49,11 @@ const CompareGamesPage = (summariesObject: Object) => {
       <div className="flex-grow border-t-2 border-black py-4" />
       {/* Compared Games Library Component
         Uses "Same Games" method  */}
+      {isFriendsLibraryPublic == true ? (
+        <p> Library!</p>
+      ) : (
+        <p>Friends Library Not Public</p>
+      )}
       <Link to="/">
         <p>Back to Home</p>
       </Link>

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -4,6 +4,7 @@ import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
 import getOwnedGames from "../../hooks/get-owned-games"
+
 const axios = require("axios")
 
 const pageTitle = "Compared Games"
@@ -12,7 +13,10 @@ const pageTitle = "Compared Games"
 const CompareGamesPage = (summariesObject: Object) => {
   let userOwnedGames = []
   let friendOwnedGames = []
+  const [commonGames, setCommonGames] = React.useState([])
+
   React.useEffect(() => {
+    // Get User Games
     getOwnedGames(summariesObject.location.state.userSummary.steamid)
       .then((returnedUserGames: Array<Object>) => {
         userOwnedGames = returnedUserGames
@@ -20,9 +24,15 @@ const CompareGamesPage = (summariesObject: Object) => {
       .catch((error: String) => {
         console.log("Error: " + error)
       })
-    // Get MyGames
-    // Get FriendsGames
-    // Get ComparedGames
+    // Get Friend's Games
+    getOwnedGames(summariesObject.location.state.friendSummary.friendId)
+      .then((returnedFriendGames: Array<Object>) => {
+        friendOwnedGames = returnedFriendGames
+      })
+      .catch((error: String) => {
+        console.log("Error: " + error)
+      })
+    // Get Common games
     Promise.all([])
       .then((res: Array<Object>) => {})
       .catch((error: String) => {})


### PR DESCRIPTION
# Problem 
Use "GetOwnedGames" to get the games owned between the User and the Friend, and display the Common Games that each  own

# Solution
- [x] Add "commonGames" State
- [x] Get "friendsGames"
  - [x] Handle case where "Friend's" library is not public.
- [x] Get the common games between the "User" library and the "Friend" library
- [x] Display "CommonGames" 

# Impact
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/b556dd62-8b31-4c7f-837b-bbe6edf601b9)

# Test Plan
1. Clone the repo to your local environment
2. `npm install`
3. Run `npm run dev`
4. Run `npm start` to start backend server
5. Navigate to `http://localhost:8000`
6. Click "Steam Profile"
7. Click "To Friends List"
8. Click "Compare Games" on any of the listed friends

Closes #67 
