### PR TITLE
Compare Games Between User and Friend

### DIFF
--- a/api/steam-api.js
+++ b/api/steam-api.js
@@ -77,4 +77,25 @@ router.get('/get-friends-list', cors(corsOptions) , async function (req, res) {
 });
 
 
+// Get all owned games with appinfo excluding free games
+router.get('/get-owned-games', cors(corsOptions) , async function (req, res) {
+  let steamID = req.query.steamIDParam
+  let getOwnedGames =
+  process.env.STEAM_GET_OWNED_GAMES
+    + process.env.STEAM_API_KEY // Get API Key from env
+    + '&steamid='
+    +  steamID
+    + '&format=json&include_appinfo=true'
+  axios.get(getOwnedGames)
+    .then((response) => {
+      // handle success
+      res.send(response.data)
+    })
+    .catch((error) => {
+      // handle error
+      console.log(error)
+      return
+    });
+});
+
 module.exports = router;

--- a/api/steam-api.js
+++ b/api/steam-api.js
@@ -85,7 +85,7 @@ router.get('/get-owned-games', cors(corsOptions) , async function (req, res) {
     + process.env.STEAM_API_KEY // Get API Key from env
     + '&steamid='
     +  steamID
-    + '&format=json&include_appinfo=true'
+    + '&format=json&include_appinfo=true&include_played_free_games=true'
   axios.get(getOwnedGames)
     .then((response) => {
       // handle success

--- a/src/components/hero-capsule.tsx
+++ b/src/components/hero-capsule.tsx
@@ -13,7 +13,7 @@ export const HeroCapsule = ({
   libraryCapsuleURL,
   children,
 }: HeroCapsuleProps) => {
-  const imageURL = libraryCapsuleURL + appID + "/hero_capsule.jpg"
+  const imageURL = libraryCapsuleURL + appID + "/library_600x900.jpg"
   return (
     <div>
       {/* If image does not successfully render */}

--- a/src/hooks/check-empty-object.tsx
+++ b/src/hooks/check-empty-object.tsx
@@ -1,0 +1,11 @@
+function isEmpty(obj: Object) {
+  for (const prop in obj) {
+    if (Object.hasOwn(obj, prop)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export default isEmpty

--- a/src/hooks/find-common-games.tsx
+++ b/src/hooks/find-common-games.tsx
@@ -1,0 +1,39 @@
+import axios from "axios"
+import getOwnedGames from "./get-owned-games"
+import isEmpty from "./check-empty-object"
+
+function findCommonGames(userSteamId: String, friendSteamId: String) {
+  let userOwnedGames: Object[] = []
+  let friendOwnedGames: Object[] = []
+  let commonGames: Map<String, String> = new Map()
+
+  return Promise.all([getOwnedGames(userSteamId), getOwnedGames(friendSteamId)])
+    .then((res: any) => {
+      if (isEmpty(res[0]) || isEmpty(res[1])) return []
+      if (res[0].length > res[1].length) {
+        // make a map with larger array's appid as key
+        let userGameMap = new Map(res[0].map((game) => [game.appid, game.name]))
+        // filter userGames array for games with appid in "userGameMap"
+        let commonGames = res[1].filter((friendGame) =>
+          userGameMap.has(friendGame.appid)
+        )
+        return commonGames
+      } else {
+        // make a map with larger array's appid as key
+        let friendGameMap = new Map(
+          res[1].map((game) => [game.appid, game.name])
+        )
+        // filter userGames array for games with appid in "friendGameMap"
+        let commonGames = res[0].filter((friendGame) =>
+          userGameMap.has(friendGame.appid)
+        )
+        return commonGames
+      }
+    })
+    .catch((err: any) => {
+      console.log(err)
+      return
+    })
+}
+
+export default findCommonGames

--- a/src/hooks/get-owned-games.tsx
+++ b/src/hooks/get-owned-games.tsx
@@ -1,0 +1,19 @@
+import axios from "axios"
+
+function getOwnedGames(id: string) {
+  return axios
+    .get("http://localhost:3000/steam-api/get-owned-games", {
+      params: {
+        steamIDParam: id,
+      },
+    })
+    .then((res: Object) => {
+      return res.data.response.games
+    })
+    .catch((error: String) => {
+      // handle error
+      console.log("Error: " + error)
+    })
+}
+
+export default getOwnedGames

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -3,13 +3,23 @@ import * as React from "react"
 import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
+import getOwnedGames from "../../hooks/get-owned-games"
 const axios = require("axios")
 
 const pageTitle = "Compared Games"
 
 // Get playerSummary and Friendslist from previous component
 const CompareGamesPage = (summariesObject: Object) => {
+  let userOwnedGames = []
+  let friendOwnedGames = []
   React.useEffect(() => {
+    getOwnedGames(summariesObject.location.state.userSummary.steamid)
+      .then((returnedUserGames: Array<Object>) => {
+        userOwnedGames = returnedUserGames
+      })
+      .catch((error: String) => {
+        console.log("Error: " + error)
+      })
     // Get MyGames
     // Get FriendsGames
     // Get ComparedGames
@@ -20,7 +30,7 @@ const CompareGamesPage = (summariesObject: Object) => {
 
   return (
     <Layout pageTitle={pageTitle}>
-      <div className=" grid divide-x-4 grid-cols-2">
+      <div className=" grid grid-cols-2 divide-x-4">
         <PlayerSummary
           personaName={summariesObject.location.state.userSummary.personaname}
           imageURL={summariesObject.location.state.userSummary.avatarfull}
@@ -34,7 +44,7 @@ const CompareGamesPage = (summariesObject: Object) => {
       </div>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
-      {/* Games Library Component
+      {/* Compared Games Library Component
         Uses "Same Games" method  */}
       <Link to="/">
         <p>Back to Home</p>

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -1,0 +1,50 @@
+import { Link } from "gatsby"
+import * as React from "react"
+import Layout from "../../components/layout"
+import { SEO } from "../../components/seo"
+import PlayerSummary from "../../components/playersummary"
+const axios = require("axios")
+
+const pageTitle = "Compared Games"
+
+// Get playerSummary and Friendslist from previous component
+const CompareGamesPage = (summariesObject: Object) => {
+  React.useEffect(() => {
+    // Get MyGames
+    // Get FriendsGames
+    // Get ComparedGames
+    Promise.all([])
+      .then((res: Array<Object>) => {})
+      .catch((error: String) => {})
+  }, [])
+
+  return (
+    <Layout pageTitle={pageTitle}>
+      <div className=" grid divide-x-4 grid-cols-2">
+        <PlayerSummary
+          personaName={summariesObject.location.state.userSummary.personaname}
+          imageURL={summariesObject.location.state.userSummary.avatarfull}
+          children={undefined}
+        />
+        <PlayerSummary
+          personaName={summariesObject.location.state.friendSummary.personaName}
+          imageURL={summariesObject.location.state.friendSummary.avatarImage}
+          children={undefined}
+        />
+      </div>
+      <hr className="py-4 " />
+      <div className="flex-grow border-t-2 border-black py-4" />
+      {/* Games Library Component
+        Uses "Same Games" method  */}
+      <Link to="/">
+        <p>Back to Home</p>
+      </Link>
+    </Layout>
+  )
+}
+
+export default CompareGamesPage
+
+export const Head = () => (
+  <SEO title={pageTitle} description={""} pathname={""} children={undefined} />
+)

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -1,30 +1,34 @@
-import { Link } from "gatsby"
+import { Link, navigate } from "gatsby"
 import * as React from "react"
 import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
 import getOwnedGames from "../../hooks/get-owned-games"
+import findCommonGames from "../../hooks/find-common-games"
+import RecentLibrary from "../../components/recent-library"
+
 const axios = require("axios")
 
 const pageTitle = "Compared Games"
 
 // Get playerSummary and Friendslist from previous component
 const CompareGamesPage = (summariesObject: Object) => {
-  let userOwnedGames = []
-  let friendOwnedGames = []
+  let isFriendsLibraryPublic = true
+  const [commonGames, setCommonGames] = React.useState([])
+
   React.useEffect(() => {
-    getOwnedGames(summariesObject.location.state.userSummary.steamid)
-      .then((returnedUserGames: Array<Object>) => {
-        userOwnedGames = returnedUserGames
+    // Get Common games
+
+    Promise.all([
+      findCommonGames(
+        summariesObject.location.state.userSummary.steamid,
+        summariesObject.location.state.friendSummary.friendId
+      ),
+    ])
+      .then((res: any) => {
+        if (res[0].length == 0) publicFriendsLibrary = false
+        setCommonGames(res[0])
       })
-      .catch((error: String) => {
-        console.log("Error: " + error)
-      })
-    // Get MyGames
-    // Get FriendsGames
-    // Get ComparedGames
-    Promise.all([])
-      .then((res: Array<Object>) => {})
       .catch((error: String) => {})
   }, [])
 
@@ -44,11 +48,24 @@ const CompareGamesPage = (summariesObject: Object) => {
       </div>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
-      {/* Compared Games Library Component
-        Uses "Same Games" method  */}
+      <button
+        onClick={async (event) => {
+          await navigate(-1)
+        }}
+      >
+        <p>Back to Friends List</p>
+      </button>
       <Link to="/">
         <p>Back to Home</p>
       </Link>
+      {isFriendsLibraryPublic == true ? (
+        <RecentLibrary
+          recentlyPlayedLibrary={commonGames}
+          children={undefined}
+        />
+      ) : (
+        <p>Friends Library Not Public</p>
+      )}
     </Layout>
   )
 }

--- a/src/pages/steam/friends-list.tsx
+++ b/src/pages/steam/friends-list.tsx
@@ -1,18 +1,18 @@
 import React from "react"
-import { SEO } from "../components/seo"
+import { SEO } from "../../components/seo"
 import axios from "axios"
-import Layout from "../components/layout"
-import PlayerSummary from "../components/playersummary"
-import getFriendsSummaries from "../hooks/get-all-friends-summaries"
+import Layout from "../../components/layout"
+import PlayerSummary from "../../components/playersummary"
+import getFriendsSummaries from "../../hooks/get-all-friends-summaries"
+import { Link } from "gatsby"
 
 const pageTitle: string = "Friend's List"
 
 const FriendsListPage = (paramObject: Object) => {
   const [friendsSummary, setFriendsSummary] = React.useState<Array<Object>>([])
-  let resultArray: Object[] = []
-  let steamId = paramObject.location.state.yourSteamId
+  let userSummary: Object = paramObject.location.state.playerSummary
   React.useEffect(() => {
-    getFriendsSummaries(steamId)
+    getFriendsSummaries(paramObject.location.state.playerSummary.steamid)
       .then((friendsSummaries: Array<Object>) => {
         setFriendsSummary(friendsSummaries)
       })
@@ -34,12 +34,13 @@ const FriendsListPage = (paramObject: Object) => {
               />
             </div>
             <div className="flex basis-1/4 items-center justify-center">
-              <button
-                formAction=""
+              <Link
                 className="flex grow justify-center rounded-full bg-sky-600 text-white"
+                to="/steam/compare-games"
+                state={{userSummary, friendSummary: friend}}
               >
-                Compare Games
-              </button>
+                <p>Compare Games</p>
+              </Link>
             </div>
           </div>
         ))

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -45,7 +45,7 @@ const ProfilePage = () => {
         imageURL={playerSummary.avatarfull}
         children={undefined}
       />
-      <Link to="/friends-list" state={{ yourSteamId }}>
+      <Link to="/steam/friends-list" state={{ playerSummary }}>
         <p>To Friends List</p>
       </Link>
       <hr className="py-4 " />


### PR DESCRIPTION
# Problem 
We want to get the games that are common between the "User" Steam library and the "Friend" Steam library

# Solution
- Add 'Compare Games' button to  "Friends List"
- On-click, redirect to "Compare Games" page
- Display User player summary and Friend player summary
- Implement api call to "[GetOwnedGames](https://developer.valvesoftware.com/wiki/Steam_Web_API#GetOwnedGames_.28v0001.29)"
- Use api call to get owned games for "User" and "Friend"
- Return as "common games"
- Display common games 

# Impact

## Display common games
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/b556dd62-8b31-4c7f-837b-bbe6edf601b9)

# Test Plan
1. Clone the repo to your local environment
2. `npm install`
3. Run `npm run dev`
4. Run `npm start` to start backend server
5. Navigate to `http://localhost:8000`
6. Click "Steam Profile"
7. Click "To Friends List"
8. Click "Compare Games" on any of the listed friends

Closes #58 
