### PR TITLE
Search for Steam ID to redirect to Profile Page

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import Navbar from "./navbar"
 import Searchbar from "./searchbar"
+import isEmpty from "../hooks/check-empty-object"
 
 type LayoutProps = {
   pageTitle: string
@@ -11,6 +12,10 @@ const Layout = ({ pageTitle, children }: LayoutProps) => {
   const [propState, setPropState] = React.useState(false)
   const [userSummary, setUserSummary] = React.useState({})
   // if userSummary is populated, route to Profile Page
+  if (isEmpty(userSummary)) console.log("userSummary emplty")
+  else {
+    setPropState(true)
+  }
   return (
     <div>
       <div className="container mx-auto flex basis-full items-center justify-center pb-4">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { Link } from "gatsby"
 import Navbar from "./navbar"
 import Searchbar from "./searchbar"
 
@@ -9,17 +8,14 @@ type LayoutProps = {
 }
 
 const Layout = ({ pageTitle, children }: LayoutProps) => {
+  const [propState, setPropState] = React.useState(false)
   const [userSummary, setUserSummary] = React.useState({})
-  const [userFound, setUserFound] = React.useState(0) // 0 if not found, 1 if found, etc
-
+  // if userSummary is populated, route to Profile Page
   return (
     <div>
       <div className="container mx-auto flex basis-full items-center justify-center pb-4">
         <Navbar />
-        <Searchbar
-          setUserSummary={setUserSummary}
-          setUserFound={setUserFound}
-        />
+        <Searchbar userSummary={userSummary} setUserSummary={setUserSummary} />
       </div>
       <main>
         <div className="container mx-auto flex flex-col justify-center">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import Navbar from "./navbar"
 import Searchbar from "./searchbar"
-import isEmpty from "../hooks/check-empty-object"
 
 type LayoutProps = {
   pageTitle: string
@@ -9,18 +8,11 @@ type LayoutProps = {
 }
 
 const Layout = ({ pageTitle, children }: LayoutProps) => {
-  const [propState, setPropState] = React.useState(false)
-  const [userSummary, setUserSummary] = React.useState({})
-  // if userSummary is populated, route to Profile Page
-  if (isEmpty(userSummary)) console.log("userSummary emplty")
-  else {
-    setPropState(true)
-  }
   return (
     <div>
       <div className="container mx-auto flex basis-full items-center justify-center pb-4">
         <Navbar />
-        <Searchbar userSummary={userSummary} setUserSummary={setUserSummary} />
+        <Searchbar />
       </div>
       <main>
         <div className="container mx-auto flex flex-col justify-center">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -9,11 +9,17 @@ type LayoutProps = {
 }
 
 const Layout = ({ pageTitle, children }: LayoutProps) => {
+  const [userSummary, setUserSummary] = React.useState({})
+  const [userFound, setUserFound] = React.useState(0) // 0 if not found, 1 if found, etc
+
   return (
     <div>
       <div className="container mx-auto flex basis-full items-center justify-center pb-4">
         <Navbar />
-        <Searchbar />
+        <Searchbar
+          setUserSummary={setUserSummary}
+          setUserFound={setUserFound}
+        />
       </div>
       <main>
         <div className="container mx-auto flex flex-col justify-center">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -11,7 +11,7 @@ type LayoutProps = {
 const Layout = ({ pageTitle, children }: LayoutProps) => {
   return (
     <div>
-      <div className="container mx-auto flex basis-full justify-center pb-4">
+      <div className="container mx-auto flex basis-full items-center justify-center pb-4">
         <Navbar />
         <Searchbar />
       </div>

--- a/src/components/recent-library.tsx
+++ b/src/components/recent-library.tsx
@@ -3,18 +3,20 @@ import HeroCapsule from "../components/hero-capsule"
 
 type RecentLibraryProps = {
   recentlyPlayedLibrary: Array<Object>
+  title: string
   children: React.ReactNode
 }
 
 export const RecentLibrary = ({
   recentlyPlayedLibrary,
+  title,
   children,
 }: RecentLibraryProps) => {
   const steamContentServer =
     "https://cdn.cloudflare.steamstatic.com/steam/apps/"
   return (
     <div>
-      <h1 className="pb-8 text-2xl font-bold underline">Recently Played</h1>
+      <h1 className="pb-8 text-2xl font-bold underline">{title}</h1>
       <div className="grid grid-cols-5 flex-row items-center gap-4">
         {recentlyPlayedLibrary.map((game: Object) => (
           <HeroCapsule

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,12 +1,15 @@
 import * as React from "react"
+import getPlayerSummary from "../hooks/get-player-summary"
 
 const Searchbar = () => {
-  const [userSteamId, setUserSteamId] = React.useState("")
-
+  const [searchedSteamId, setSearchedSteamId] = React.useState("")
   const handleSubmit = (event: any) => {
     // Prevent the browser from reloading the page
     event.preventDefault()
     // Make call to get Player summary and Recently played games
+    getPlayerSummary(searchedSteamId)
+      .then((res: Object) => {})
+      .catch((err: any) => console.log("ERROR: " + err))
     // Link to ProfilePage with player summary and recently played games
   }
   return (
@@ -16,8 +19,8 @@ const Searchbar = () => {
           className="h-4/6 w-auto rounded-md border-slate-300 bg-black text-white placeholder-white"
           type="text"
           placeholder="Enter Steam Id"
-          value={userSteamId}
-          onChange={(e) => setUserSteamId(e.target.value)}
+          value={searchedSteamId}
+          onChange={(e) => setSearchedSteamId(e.target.value)}
         />
         <button
           type="submit"

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,25 +1,15 @@
 import * as React from "react"
 import getPlayerSummary from "../hooks/get-player-summary"
-import {navigate} from '@reach/router'
+import { navigate } from "@reach/router"
 
-type SearchbarProps = {
-  userSummary : Object,
-  setUserSummary : React.Dispatch<React.SetStateAction<Object>>
-}
-
-const Searchbar = ({userSummary, setUserSummary}: SearchbarProps) => {
+const Searchbar = () => {
   const [userSteamId, setUserSteamId] = React.useState("")
-
   const handleSubmit = (event: any) => {
     // Prevent the browser from reloading the page
     event.preventDefault()
-    // Make call to get Player summary and Recently played games
-    if(userSteamId != "" && typeof userSteamId === 'string')  {
-      let searchResult = getPlayerSummary(userSteamId)
-      setUserSummary(searchResult)
-      navigate('/steam/profile')
+    if (userSteamId != "" && typeof userSteamId === "string") {
+      navigate("/steam/profile/", { state: { userSteamId } })
     }
-    // Link to ProfilePage with player summary and recently played games
   }
   return (
     <div className="flex flex-row items-center align-middle">

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,25 +1,28 @@
 import * as React from "react"
 
-// Handle formAction
-// Link to ProfilePage with entered steam id as param
-function handleSubmit() {}
-
 const Searchbar = () => {
   const [userSteamId, setUserSteamId] = React.useState("")
-  function handleSubmit(e: any) {
+
+  const handleSubmit = (event: any) => {
     // Prevent the browser from reloading the page
-    e.preventDefault()
+    event.preventDefault()
+    // Make call to get Player summary and Recently played games
+    // Link to ProfilePage with player summary and recently played games
   }
   return (
     <div className="flex flex-row items-center align-middle">
-      <form className="flex flex-row items-center">
+      <form onSubmit={handleSubmit} className="flex flex-row items-center">
         <input
           className="h-4/6 w-auto rounded-md border-slate-300 bg-black text-white placeholder-white"
           type="text"
           placeholder="Enter Steam Id"
-          onSubmit={handleSubmit}
+          value={userSteamId}
+          onChange={(e) => setUserSteamId(e.target.value)}
         />
-        <button className="h-4/6 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700">
+        <button
+          type="submit"
+          className="h-4/6 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+        >
           Search
         </button>
       </form>

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,15 +1,20 @@
 import * as React from "react"
 import getPlayerSummary from "../hooks/get-player-summary"
+type SearchbarProps = {
+  userSummary : Object,
+  setUserSummary : React.Dispatch<React.SetStateAction<Object>>
+}
 
-const Searchbar = () => {
-  const [searchedSteamId, setSearchedSteamId] = React.useState("")
+const Searchbar = ({userSummary, setUserSummary}: SearchbarProps) => {
+  const [userSteamId, setUserSteamId] = React.useState("")
+
   const handleSubmit = (event: any) => {
     // Prevent the browser from reloading the page
     event.preventDefault()
     // Make call to get Player summary and Recently played games
-    getPlayerSummary(searchedSteamId)
-      .then((res: Object) => {})
-      .catch((err: any) => console.log("ERROR: " + err))
+    if(userSteamId != "" && typeof userSteamId === 'string')  {
+      getPlayerSummary(userSteamId)
+    }
     // Link to ProfilePage with player summary and recently played games
   }
   return (
@@ -19,8 +24,8 @@ const Searchbar = () => {
           className="h-4/6 w-auto rounded-md border-slate-300 bg-black text-white placeholder-white"
           type="text"
           placeholder="Enter Steam Id"
-          value={searchedSteamId}
-          onChange={(e) => setSearchedSteamId(e.target.value)}
+          value={userSteamId}
+          onChange={(e) => setUserSteamId(e.target.value)}
         />
         <button
           type="submit"

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
 import getPlayerSummary from "../hooks/get-player-summary"
+import {navigate} from '@reach/router'
+
 type SearchbarProps = {
   userSummary : Object,
   setUserSummary : React.Dispatch<React.SetStateAction<Object>>
@@ -13,7 +15,9 @@ const Searchbar = ({userSummary, setUserSummary}: SearchbarProps) => {
     event.preventDefault()
     // Make call to get Player summary and Recently played games
     if(userSteamId != "" && typeof userSteamId === 'string')  {
-      getPlayerSummary(userSteamId)
+      let searchResult = getPlayerSummary(userSteamId)
+      setUserSummary(searchResult)
+      navigate('/steam/profile')
     }
     // Link to ProfilePage with player summary and recently played games
   }

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -1,5 +1,8 @@
 import * as React from "react"
 
+// Handle formAction
+// Link to ProfilePage with entered steam id as param
+
 const Searchbar = () => {
   return (
     <div className="flex flex-row align-middle">

--- a/src/components/searchbar.tsx
+++ b/src/components/searchbar.tsx
@@ -2,26 +2,27 @@ import * as React from "react"
 
 // Handle formAction
 // Link to ProfilePage with entered steam id as param
+function handleSubmit() {}
 
 const Searchbar = () => {
+  const [userSteamId, setUserSteamId] = React.useState("")
+  function handleSubmit(e: any) {
+    // Prevent the browser from reloading the page
+    e.preventDefault()
+  }
   return (
-    <div className="flex flex-row align-middle">
-      <div>
+    <div className="flex flex-row items-center align-middle">
+      <form className="flex flex-row items-center">
         <input
-          className="h-4/6 w-auto rounded-md border-slate-300 bg-black placeholder-white"
+          className="h-4/6 w-auto rounded-md border-slate-300 bg-black text-white placeholder-white"
           type="text"
           placeholder="Enter Steam Id"
-          formAction="POST"
+          onSubmit={handleSubmit}
         />
-      </div>
-      <div>
-        <button
-          className="h-4/6 justify-center rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
-        >
+        <button className="h-4/6 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700">
           Search
         </button>
-      </div>
-      
+      </form>
     </div>
   )
 }

--- a/src/hooks/UserSummaryContext.ts
+++ b/src/hooks/UserSummaryContext.ts
@@ -1,0 +1,3 @@
+import {createContext} from "react"
+
+export const UserSummaryContext = createContext({})

--- a/src/hooks/get-player-summary.tsx
+++ b/src/hooks/get-player-summary.tsx
@@ -1,0 +1,20 @@
+import axios from "axios"
+
+function getPlayerSummary(id: String) {
+  return axios
+    .get("http://localhost:3000/steam-api/get-player-summary", {
+      params: {
+        steamIDParam: id,
+      },
+    })
+    .then((res: any) => {
+      // handle success
+      return res.data.response.players[0]
+    })
+    .catch((error: String) => {
+      // handle error
+      console.log("Error: " + error)
+    })
+}
+
+export default getPlayerSummary

--- a/src/hooks/get-recently-played-games.tsx
+++ b/src/hooks/get-recently-played-games.tsx
@@ -1,14 +1,14 @@
 import axios from "axios"
 
-function getPlayerSummary(id: string) {
+function getRecentlyPlayedGames(id: string) {
   return axios
-    .get("http://localhost:3000/steam-api/get-player-summary", {
+    .get("http://localhost:3000/steam-api/get-recently-played-games", {
       params: {
         steamIDParam: id,
       },
     })
     .then((res: Object) => {
-      return res.data.response.players[0]
+      return res.data.response.games
     })
     .catch((error: String) => {
       // handle error
@@ -16,4 +16,4 @@ function getPlayerSummary(id: string) {
     })
 }
 
-export default getPlayerSummary
+export default getRecentlyPlayedGames

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import Layout from "../components/layout"
+import { SEO } from "../components/seo"
+
+const HomePage = () => {
+  return (
+    <Layout pageTitle="Steam Reaction" >
+      <p className="text-center">
+        Do you ever have trouble finding searching through your huge Steam
+        library for games you and your friends own?
+      </p>
+      <p className="text-center">
+        Just enter your Steam Id in the search bar above, and choose a friend!
+      </p>
+    </Layout>
+  )
+}
+
+export const Head = () => (
+  <SEO title={""} description={""} pathname={""} children={undefined} />
+)
+
+export default HomePage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,37 +1,12 @@
 import * as React from "react"
-import Layout from "../components/layout"
 import { SEO } from "../components/seo"
-import ProfilePage from "./steam/profile"
-import { UserSummaryContext } from "../hooks/UserSummaryContext"
+import HomePage from "./home"
 
-const HomePage = () => {
-  const [propState, setPropState] = React.useState(false)
-  const [userSummary, setUserSummary] = React.useState({})
-  return (
-    <UserSummaryContext.Provider userObject={""}>
-      <Layout pageTitle="Steam Reaction">
-        <p className="text-center">
-          Do you ever have trouble finding searching through your huge Steam
-          library for games you and your friends own?
-        </p>
-        <p className="text-center">
-          Just enter your Steam Id in the search bar above, and choose a friend!
-        </p>
-        {propState ? (
-          <ProfilePage
-            userSummary={userSummary}
-            setUserSummary={setUserSummary}
-          />
-        ) : (
-          <p>No user yet</p>
-        )}
-      </Layout>
-    </UserSummaryContext.Provider>
-  )
+const App = () => {
+  return <HomePage />
 }
 
 export const Head = () => (
   <SEO title={""} description={""} pathname={""} children={undefined} />
 )
-
-export default HomePage
+export default App

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,32 @@
 import * as React from "react"
 import Layout from "../components/layout"
 import { SEO } from "../components/seo"
+import ProfilePage from "./steam/profile"
+import { UserSummaryContext } from "../hooks/UserSummaryContext"
 
 const HomePage = () => {
+  const [propState, setPropState] = React.useState(false)
+  const [userSummary, setUserSummary] = React.useState({})
   return (
-    <Layout pageTitle="Steam Reaction">
-      <p className="text-center">Do you ever have trouble finding searching through your huge Steam library for games you and your friends own?</p>
-      <p className="text-center">Just enter your Steam Id in the search bar above, and choose a friend!</p>
-    </Layout>
+    <UserSummaryContext.Provider userObject={""}>
+      <Layout pageTitle="Steam Reaction">
+        <p className="text-center">
+          Do you ever have trouble finding searching through your huge Steam
+          library for games you and your friends own?
+        </p>
+        <p className="text-center">
+          Just enter your Steam Id in the search bar above, and choose a friend!
+        </p>
+        {propState ? (
+          <ProfilePage
+            userSummary={userSummary}
+            setUserSummary={setUserSummary}
+          />
+        ) : (
+          <p>No user yet</p>
+        )}
+      </Layout>
+    </UserSummaryContext.Provider>
   )
 }
 

--- a/src/pages/steam/compare-games.tsx
+++ b/src/pages/steam/compare-games.tsx
@@ -48,18 +48,21 @@ const CompareGamesPage = (summariesObject: Object) => {
       </div>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
-      <button
-        onClick={async (event) => {
-          await navigate(-1)
-        }}
-      >
-        <p>Back to Friends List</p>
-      </button>
+      <div>
+        <button
+          onClick={async (event) => {
+            await navigate(-1)
+          }}
+        >
+          <p>Back to Friends List</p>
+        </button>
+      </div>
       <Link to="/">
         <p>Back to Home</p>
       </Link>
       {isFriendsLibraryPublic == true ? (
         <RecentLibrary
+          title="List of Common Games"
           recentlyPlayedLibrary={commonGames}
           children={undefined}
         />

--- a/src/pages/steam/friends-list.tsx
+++ b/src/pages/steam/friends-list.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { SEO } from "../../components/seo"
-import axios from "axios"
 import Layout from "../../components/layout"
 import PlayerSummary from "../../components/playersummary"
 import getFriendsSummaries from "../../hooks/get-all-friends-summaries"
@@ -10,9 +9,9 @@ const pageTitle: string = "Friend's List"
 
 const FriendsListPage = (paramObject: Object) => {
   const [friendsSummary, setFriendsSummary] = React.useState<Array<Object>>([])
-  let userSummary: Object = paramObject.location.state.playerSummary
+  let userSummary: Object = paramObject.location.state.userSummary
   React.useEffect(() => {
-    getFriendsSummaries(paramObject.location.state.playerSummary.steamid)
+    getFriendsSummaries(paramObject.location.state.userSummary.steamid)
       .then((friendsSummaries: Array<Object>) => {
         setFriendsSummary(friendsSummaries)
       })

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -8,41 +8,24 @@ const axios = require("axios")
 
 const profileName = "Search Result"
 
-const ProfilePage = () => {
+type ProfilePageProps = {
+  userSummary: Object
+  setUserSummary: React.Dispatch<React.SetStateAction<Object>>
+}
+
+const ProfilePage = ({ userSummary, setUserSummary }: ProfilePageProps) => {
   const yourSteamId = "76561198161853165"
   const [playerSummary, setPlayerSummary] = React.useState({})
   const [recentlyPlayed, setRecentlyPlayed] = React.useState([])
 
   // Call get-steam-user with user supplied yourSteamId
-  React.useEffect(() => {
-    Promise.all([
-      axios.get("http://localhost:3000/steam-api/get-player-summary", {
-        params: {
-          steamIDParam: yourSteamId,
-        },
-      }),
-      axios.get("http://localhost:3000/steam-api/get-recently-played-games", {
-        params: {
-          steamIDParam: yourSteamId,
-        },
-      }),
-    ])
-      .then((res: Array<Object>) => {
-        // handle success
-        setPlayerSummary(res[0].data.response.players[0])
-        setRecentlyPlayed(res[1].data.response.games)
-      })
-      .catch((error: String) => {
-        // handle error
-        console.log("Error: " + error)
-      })
-  }, [])
+  React.useEffect(() => {}, [])
 
   return (
     <Layout pageTitle={profileName}>
       <PlayerSummary
-        personaName={playerSummary.personaname}
-        imageURL={playerSummary.avatarfull}
+        personaName={userSummary.personaname}
+        imageURL={userSummary.avatarfull}
         children={undefined}
       />
       <Link to="/steam/friends-list" state={{ playerSummary }}>

--- a/src/pages/steam/profile.tsx
+++ b/src/pages/steam/profile.tsx
@@ -4,22 +4,37 @@ import Layout from "../../components/layout"
 import { SEO } from "../../components/seo"
 import PlayerSummary from "../../components/playersummary"
 import { RecentLibrary } from "../../components/recent-library"
-const axios = require("axios")
+import getRecentlyPlayedGames from "../../hooks/get-recently-played-games"
+import getPlayerSummary from "../../hooks/get-player-summary"
 
 const profileName = "Search Result"
 
-type ProfilePageProps = {
-  userSummary: Object
-  setUserSummary: React.Dispatch<React.SetStateAction<Object>>
-}
-
-const ProfilePage = ({ userSummary, setUserSummary }: ProfilePageProps) => {
-  const yourSteamId = "76561198161853165"
-  const [playerSummary, setPlayerSummary] = React.useState({})
+const ProfilePage = (paramObject: Object) => {
+  let yourSteamId = ""
+  const [userSummary, setUserSummary] = React.useState({})
   const [recentlyPlayed, setRecentlyPlayed] = React.useState([])
-
   // Call get-steam-user with user supplied yourSteamId
-  React.useEffect(() => {}, [])
+  React.useEffect(() => {
+    if (
+      paramObject.location.state.userSteamId != null ||
+      paramObject.location.state.userSteamId != undefined
+    ) {
+      yourSteamId = paramObject.location.state.userSteamId
+      getRecentlyPlayedGames(yourSteamId)
+        .then((res: Array<Object>) => {
+          setRecentlyPlayed(res)
+        })
+        .catch((err: string) => {})
+      getPlayerSummary(yourSteamId)
+        .then((res: Object) => {
+          setUserSummary(res)
+        })
+        .catch((err: string) => {
+          console.log(err)
+        })
+    }
+    
+  }, [])
 
   return (
     <Layout pageTitle={profileName}>
@@ -28,13 +43,14 @@ const ProfilePage = ({ userSummary, setUserSummary }: ProfilePageProps) => {
         imageURL={userSummary.avatarfull}
         children={undefined}
       />
-      <Link to="/steam/friends-list" state={{ playerSummary }}>
+      <Link to="/steam/friends-list" state={{ userSummary }}>
         <p>To Friends List</p>
       </Link>
       <hr className="py-4 " />
       <div className="flex-grow border-t-2 border-black py-4" />
       <RecentLibrary
         recentlyPlayedLibrary={recentlyPlayed}
+        title="Recently Played Library"
         children={undefined}
       />
       <Link to="/">


### PR DESCRIPTION
# Problem 
Search for steam ID to redirect to appropriate Profile page

# Solution
- [x] Get `userSteamId` from Search Bar
- [x] Use `userSteamId` playerSummary and recentlyplayedgame for entered steam id
- [x] Render "Profile Page" with playerSummary and recentPlayedGames passed as props

# Impact
## Search for spilledcoffee steam id
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/6ad8b4df-b032-45c4-8950-e809331ea279)
## Navigate to profile page
![image](https://github.com/Darcmarc78/steam-reaction/assets/20177405/191f033a-dd4f-45b2-ba30-894bb2abb556)

# Test Plan
1. Clone the repo to your local environment
2. `npm install`
3. Run `npm run dev`
4. Run `npm start` to start backend server
5. Navigate to `http://localhost:8000`
6. Enter steam Id of user you want to find in search bar
7. Press enter or click on "Search"


# Known Issues
- Non successful search is not handled gracefully yet
  - Handle bad requests in backend server

Closes #56 
